### PR TITLE
Allow the engine to use a native configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.3.8" withSources(),
   "org.scala-lang.modules" %% "scala-xml" % "1.0.4" withSources(),
-  "com.codacy" %% "codacy-engine-scala-seed" % "2.7.0"
+  "com.codacy" %% "codacy-engine-scala-seed" % "2.7.1"
 )
 
 enablePlugins(JavaAppPackaging)
@@ -28,7 +28,7 @@ version in Docker := "1.0"
 val installAll =
   s"""apk update && apk add bash
      |&& apk add nodejs
-     |&& npm install -g https://github.com/rtfpessoa/csslint/archive/v0.10.1.tar.gz
+     |&& npm install -g csslint
    """.stripMargin.replaceAll(System.lineSeparator(), " ")
 
 mappings in Universal <++= (resourceDirectory in Compile) map { (resourceDir: File) =>

--- a/src/main/scala/codacy/csslint/CSSLint.scala
+++ b/src/main/scala/codacy/csslint/CSSLint.scala
@@ -1,47 +1,36 @@
 package codacy.csslint
 
-import java.nio.file.Path
+import codacy.docker.api._
+import codacy.dockerApi.utils.CommandRunner
 
-import codacy.dockerApi._
-import codacy.dockerApi.utils.{CommandRunner, ToolHelper}
-
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object CSSLint extends Tool {
 
-  override def apply(path: Path, conf: Option[List[PatternDef]], files: Option[Set[Path]])(implicit spec: Spec): Try[List[Result]] = {
-    Try {
-      val fullConfig = ToolHelper.getPatternsToLint(conf)
-      val filesToLint: List[String] = files.fold(List(path.toString)) {
-        paths =>
-          paths.map(_.toString).toList
-      }
+  lazy val CssLintMatch = """(.*): line ([0-9]*),.*, ([a-zA-Z]+) - (.*) \((.*)\)""".r
 
-      val command = List("csslint", "--format=codacy") ++ filesToLint
+  override def apply(source: Source.Directory, configuration: Option[List[Pattern.Definition]], files: Option[Set[Source.File]])
+                    (implicit specification: Tool.Specification): Try[List[Result]] = {
 
-      CommandRunner.exec(command) match {
-        case Right(resultFromTool) =>
-          parseResult(resultFromTool.stdout, fullConfig)
-        case Left(failure) =>
-          throw failure
-      }
-    }
+    val sourceDir = better.files.File(source.path)
+
+    val filesToLint = files.map(_.map(_.path)).getOrElse(Set(source.path))
+    val command = List("csslint", "--format=compact") /*++ nativeConfigParams */++ filesToLint
+
+    if(configuration.isDefined) (better.files.File(source.path) / ".csslintrc").delete(swallowIOExceptions = true)
+
+    CommandRunner.exec(command, dir = Some(sourceDir.toJava))
+      .fold(Failure.apply, res => Success(parseResult(res.stdout, configuration)))
   }
 
-  def parseResult(lines: List[String], fullConfig: Option[List[PatternDef]]): List[Result] = {
-    val RegMatch = """(.*):>line:([0-9]+),(.*),([a-zA-Z]+):(.*)""".r
-
-    val configIds = fullConfig.toList.flatten.map(_.patternId.value)
-
-    lines.collect {
-      case RegMatch(file, line, patternId, level, message) if fullConfig.exists(_.isEmpty) || configIds.contains(patternId) =>
-        Issue(
-          SourcePath(file),
-          ResultMessage(message),
-          PatternId(patternId),
-          ResultLine(line.toInt)
-        )
+  def parseResult(lines: List[String], fullConfig: Option[List[Pattern.Definition]]): List[Result] = {
+    lines.flatMap {
+      case CssLintMatch(file, line, level, message, patternId)
+        if fullConfig.forall(_.exists(_.patternId.value == patternId)) =>
+        Try(line.toInt).map { case rLine =>
+          Result.Issue(Source.File(file), Result.Message(message), Pattern.Id(patternId), Source.Line(rLine))
+        }.toOption
+      case _ => List.empty
     }
   }
-
 }


### PR DESCRIPTION
I removed the custom version made by rodrigo in favour of the official one. I think that we were only using the custom one for the custom output formatter that is not really needed please let me know if that's wrong!

one more thing: when running an analysis WITH codacy-patterns configured i remove the native config-file from the directory if it exists. i don't know if i'm allowed to do that!