### PR TITLE
bump: Bump codacy-engine-scala-seed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := "2.13.1"
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.7.4" withSources (),
   "org.scala-lang.modules" %% "scala-xml" % "1.2.0" withSources (),
-  "com.codacy" %% "codacy-engine-scala-seed" % "5.0.0" withSources ()
+  "com.codacy" %% "codacy-engine-scala-seed" % "5.0.1" withSources ()
 )
 
 enablePlugins(JavaAppPackaging)


### PR DESCRIPTION
- Fix bug with parameters not passed in `.codacyrc`